### PR TITLE
Add junit depedency and test classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<keycloak.version>15.0.2</keycloak.version>
 		<kafka.version>2.8.0</kafka.version>
+		<junit.version>5.8.1</junit.version>
 	</properties>
 
 	<dependencies>
@@ -44,6 +45,13 @@
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
 			<version>${kafka.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProvider.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProvider.java
@@ -35,7 +35,7 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
 	private ObjectMapper mapper;
 
 	public KafkaEventListenerProvider(String bootstrapServers, String clientId, String topicEvents, String[] events,
-	    String topicAdminEvents, Map<String, Object> kafkaProducerProperties) {
+			String topicAdminEvents, Map<String, Object> kafkaProducerProperties, KafkaProducerFactory factory) {
 		this.topicEvents = topicEvents;
 		this.events = new ArrayList<>();
 		this.topicAdminEvents = topicAdminEvents;
@@ -49,12 +49,12 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
 			}
 		}
 
-		producer = KafkaProducerFactory.createProducer(clientId, bootstrapServers, kafkaProducerProperties);
+		producer = factory.createProducer(clientId, bootstrapServers, kafkaProducerProperties);
 		mapper = new ObjectMapper();
 	}
 
 	private void produceEvent(String eventAsString, String topic)
-	    throws InterruptedException, ExecutionException, TimeoutException {
+			throws InterruptedException, ExecutionException, TimeoutException {
 		LOG.debug("Produce to topic: " + topicEvents + " ...");
 		ProducerRecord<String, String> record = new ProducerRecord<>(topic, eventAsString);
 		Future<RecordMetadata> metaData = producer.send(record);

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
@@ -27,7 +27,7 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 	public EventListenerProvider create(KeycloakSession session) {
 		if (instance == null) {
 			instance = new KafkaEventListenerProvider(bootstrapServers, clientId, topicEvents, events, topicAdminEvents,
-			    kafkaProducerProperties);
+					kafkaProducerProperties, new StandardKafkaProducerFactory());
 		}
 
 		return instance;

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerFactory.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerFactory.java
@@ -1,33 +1,12 @@
 package com.github.snuk87.keycloak.kafka;
 
 import java.util.Map;
-import java.util.Properties;
 
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringSerializer;
 
-public final class KafkaProducerFactory {
+public interface KafkaProducerFactory {
 
-	private KafkaProducerFactory() {
+	Producer<String, String> createProducer(String clientId, String bootstrapServer,
+			Map<String, Object> optionalProperties);
 
-	}
-
-	public static Producer<String, String> createProducer(String clientId, String bootstrapServer,
-	    Map<String, Object> optionalProperties) {
-		Properties props = new Properties();
-		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
-		props.put(ProducerConfig.CLIENT_ID_CONFIG, clientId);
-		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-
-		optionalProperties.forEach(props::put);
-
-		// fix Class org.apache.kafka.common.serialization.StringSerializer could not be
-		// found. see https://stackoverflow.com/a/50981469
-		Thread.currentThread().setContextClassLoader(null);
-
-		return new KafkaProducer<>(props);
-	}
 }

--- a/src/main/java/com/github/snuk87/keycloak/kafka/StandardKafkaProducerFactory.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/StandardKafkaProducerFactory.java
@@ -1,0 +1,30 @@
+package com.github.snuk87.keycloak.kafka;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+public final class StandardKafkaProducerFactory implements KafkaProducerFactory {
+
+	@Override
+	public Producer<String, String> createProducer(String clientId, String bootstrapServer,
+			Map<String, Object> optionalProperties) {
+		Properties props = new Properties();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+		props.put(ProducerConfig.CLIENT_ID_CONFIG, clientId);
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+		optionalProperties.forEach(props::put);
+
+		// fix Class org.apache.kafka.common.serialization.StringSerializer could not be
+		// found. see https://stackoverflow.com/a/50981469
+		Thread.currentThread().setContextClassLoader(null);
+
+		return new KafkaProducer<>(props);
+	}
+}

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -1,0 +1,77 @@
+package com.github.snuk87.keycloak.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+
+class KafkaEventListenerProviderTests {
+
+	private KafkaEventListenerProvider listener;
+	private KafkaProducerFactory factory;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		factory = new KafkaMockProducerFactory();
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin-events", Map.of(),
+				factory);
+	}
+
+	@Test
+	void shouldProduceEventWhenTypeIsDefined() throws Exception {
+		Event event = new Event();
+		event.setType(EventType.REGISTER);
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event);
+
+		assertEquals(1, producer.history().size());
+	}
+
+	@Test
+	void shouldDoNothingWhenTypeIsNotDefined() throws Exception {
+		Event event = new Event();
+		event.setType(EventType.CLIENT_DELETE);
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event);
+
+		assertTrue(producer.history().isEmpty());
+	}
+
+	@Test
+	void shouldProduceEventWhenTopicAdminEventsIsNotNull() throws Exception {
+		AdminEvent event = new AdminEvent();
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event, false);
+
+		assertEquals(1, producer.history().size());
+	}
+
+	@Test
+	void shouldDoNothingWhenTopicAdminEventsIsNull() throws Exception {
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, Map.of(), factory);
+		AdminEvent event = new AdminEvent();
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event, false);
+
+		assertTrue(producer.history().isEmpty());
+	}
+
+	private MockProducer<?, ?> getProducerUsingReflection() throws Exception {
+		Field producerField = KafkaEventListenerProvider.class.getDeclaredField("producer");
+		producerField.setAccessible(true);
+		return (MockProducer<?, ?>) producerField.get(listener);
+	}
+
+}

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaMockProducerFactory.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaMockProducerFactory.java
@@ -1,0 +1,17 @@
+package com.github.snuk87.keycloak.kafka;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+class KafkaMockProducerFactory implements KafkaProducerFactory {
+
+	@Override
+	public Producer<String, String> createProducer(String clientId, String bootstrapServer,
+			Map<String, Object> optionalProperties) {
+		return new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+	}
+
+}

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfigTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfigTests.java
@@ -1,0 +1,24 @@
+package com.github.snuk87.keycloak.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.keycloak.Config.SystemPropertiesConfigProvider;
+
+class KafkaProducerConfigTests {
+
+	@Test
+	void shouldReturnMapWithConfigWhenPropertyExists() {
+		System.setProperty("keycloak.retry.backoff.ms", "1000");
+		System.setProperty("keycloak.max.block.ms", "5000");
+		System.setProperty("keycloak.foo", "bar");
+
+		Map<String, Object> config = KafkaProducerConfig.init(new SystemPropertiesConfigProvider().scope());
+		Map<String, Object> expected = Map.of("retry.backoff.ms", "1000", "max.block.ms", "5000");
+
+		assertEquals(expected, config);
+	}
+}


### PR DESCRIPTION
Introduced the factory pattern for the kafka producer because creating the producer inside the `EventListenerProviderFactory` class leads to an error during start up. A `MockProducer` can now be used in the test classes.