### PR TITLE
Add missing KafkaPoroducerProperty ssl.keystore.certificate.chain

### DIFF
--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfig.java
@@ -28,6 +28,7 @@ public class KafkaProducerConfig {
 		COMPRESSION_TYPE("compression.type"), //
 		RETRIES("retries"), //
 		SSL_KEY_PASSWORD("ssl.key.password"), //
+		SSL_KEYSTORE_CERTIFICATE_CHAIN("ssl.keystore.certificate.chain"), //
 		SSL_KEYSTORE_LOCATION("ssl.keystore.location"), //
 		SSL_KEYSTORE_PASSWORD("ssl.keystore.password"), //
 		SSL_TRUSTSTORE_LOCATION("ssl.truststore.location"), //


### PR DESCRIPTION
This adds a missing property [`ssl.keystore.certificate.chain`](https://kafka.apache.org/documentation/#brokerconfigs_ssl.keystore.certificate.chain) to the `KafkaProducerProperty` enum which is nomrally needed if you are using the a [`ssl.keystore.type`](https://kafka.apache.org/documentation/#brokerconfigs_ssl.keystore.type) of PEM (insstead of JKS) and want to provide the full certificate chain in x.509 PEM format.

Here is an [example of its usage](
https://codingharbour.com/apache-kafka/using-pem-certificates-with-apache-kafka/#0-providing-certificates-as-strings).