### PR TITLE
Add more environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,17 @@ The following properties can be set via environment variables (e.g. `${KAFKA_TOP
 A list of available events can be found [here](https://www.keycloak.org/docs/latest/server_admin/#event-types)
 
 ###  Kafka client configuration
-It's also possible to configure the kafka client by adding parameters to the keycloak start command. This makes it possible to connect this module to a kafka broker that requires SSL/TLS connections.
+It's also possible to configure the kafka client with environment variables or by adding parameters to the keycloak start command. This makes it possible to connect this module to a kafka broker that requires SSL/TLS connections.
 For example to change the timeout of how long the producer will block the thread to 10 seconds you just have to pass the following parameter to the start command.
 
-```
+```sh
 ./kc.sh start --spi-events-listener-kafka-max-block-ms 10000
+```
+
+Or set the following environnment variable.
+
+```sh
+KAFKA_MAX_BLOCK_MS=10000
 ```
 
 A full list of available configurations can be found in the [official kafka docs](https://kafka.apache.org/documentation/#producerconfigs).

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfig.java
@@ -14,7 +14,9 @@ public class KafkaProducerConfig {
 		KafkaProducerProperty[] producerProperties = KafkaProducerProperty.values();
 
 		for (KafkaProducerProperty property : producerProperties) {
-			if (property.getName() != null && scope.get(property.getName()) != null) {
+			String propertyEnv = System.getenv("KAFKA_" + property.name());
+
+			if (property.getName() != null && scope.get(property.getName(), propertyEnv) != null) {
 				propertyMap.put(property.getName(), scope.get(property.getName()));
 			}
 		}

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfig.java
@@ -17,7 +17,7 @@ public class KafkaProducerConfig {
 			String propertyEnv = System.getenv("KAFKA_" + property.name());
 
 			if (property.getName() != null && scope.get(property.getName(), propertyEnv) != null) {
-				propertyMap.put(property.getName(), scope.get(property.getName()));
+				propertyMap.put(property.getName(), scope.get(property.getName(), propertyEnv));
 			}
 		}
 


### PR DESCRIPTION
- Allow any Kafka client property to be configured by environment variables.

#### Justification:

Our team relies on environment variables for configuring our applications. This allows us to configure an application for different environments without having to change the code or build separate images.