### PR TITLE
Filtering Admin Events via OperationType & ResourceType

### DIFF
--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProvider.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProvider.java
@@ -34,20 +34,14 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
 
 	private ObjectMapper mapper;
 
-	private List<String> adminEventResourceTypes;
-
-	private List<String> adminEventOperationTypes;
-
 	private List<String> adminStrictEventTypes;
 
 	public KafkaEventListenerProvider(String bootstrapServers, String clientId, String topicEvents, String[] events,
-			String topicAdminEvents, String[] adminEventResourceTypes, String[] adminEventOperationTypes, String[] adminStrictEventTypes,
+			String topicAdminEvents, String[] adminStrictEventTypes,
 			Map<String, Object> kafkaProducerProperties, KafkaProducerFactory factory) {
 		this.topicEvents = topicEvents;
 		this.events = new ArrayList<>();
 		this.topicAdminEvents = topicAdminEvents;
-		this.adminEventResourceTypes = new ArrayList<>();
-		this.adminEventOperationTypes = new ArrayList<>();
 		this.adminStrictEventTypes = new ArrayList<>();
 
 		for (String event : events) {
@@ -57,12 +51,6 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
 			} catch (IllegalArgumentException e) {
 				LOG.debug("Ignoring event >" + event + "<. Event does not exist.");
 			}
-		}
-		for (String operationType : adminEventOperationTypes) {
-		  this.adminEventOperationTypes.add(operationType);
-		}
-    for (String resourceType : adminEventResourceTypes) {
-		  this.adminEventResourceTypes.add(resourceType);
 		}
     for (String strictEventType : adminStrictEventTypes) {
 		  this.adminStrictEventTypes.add(strictEventType);
@@ -105,8 +93,7 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
       return matchesStrictEventTypes(event);
     }
 
-    // Flexible matching: either operation type OR resource type can match
-    return matchesFlexibleEventTypes(event);
+    return true;
   }
 
   private boolean matchesStrictEventTypes(AdminEvent event) {
@@ -129,28 +116,6 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
     }
 
     return false;
-  }
-
-  private boolean matchesFlexibleEventTypes(AdminEvent event) {
-    boolean resourceTypesNotSet = adminEventResourceTypes == null || adminEventResourceTypes.isEmpty();
-    boolean operationTypesNotSet = adminEventOperationTypes == null || adminEventOperationTypes.isEmpty();
-
-    // If both filters are empty, accept all events
-    if (resourceTypesNotSet && operationTypesNotSet) {
-      return true;
-    }
-
-    boolean resourceTypeMatches = !resourceTypesNotSet &&
-                                  adminEventResourceTypes.contains(event.getResourceTypeAsString());
-
-    boolean operationTypeMatches = !operationTypesNotSet &&
-                                   event.getOperationType() != null &&
-                                   adminEventOperationTypes.contains(event.getOperationType().name());
-
-    // Accept if either filter matches (when only one filter is set) or both match (when both are set)
-    return (resourceTypesNotSet && operationTypeMatches) ||
-           (operationTypesNotSet && resourceTypeMatches) ||
-           (resourceTypeMatches && operationTypeMatches);
   }
 
 	@Override

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProvider.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProvider.java
@@ -34,11 +34,17 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
 
 	private ObjectMapper mapper;
 
+	private String[] adminEventResourceTypes;
+
+	private String[] adminEventOperationTypes;
+
 	public KafkaEventListenerProvider(String bootstrapServers, String clientId, String topicEvents, String[] events,
-			String topicAdminEvents, Map<String, Object> kafkaProducerProperties, KafkaProducerFactory factory) {
+			String topicAdminEvents, String[] adminEventResourceTypes, String[] adminEventOperationTypes, Map<String, Object> kafkaProducerProperties, KafkaProducerFactory factory) {
 		this.topicEvents = topicEvents;
 		this.events = new ArrayList<>();
 		this.topicAdminEvents = topicAdminEvents;
+		this.adminEventResourceTypes = adminEventResourceTypes
+		this.adminEventOperationTypes = adminEventOperationTypes
 
 		for (String event : events) {
 			try {
@@ -78,7 +84,13 @@ public class KafkaEventListenerProvider implements EventListenerProvider {
 
 	@Override
 	public void onEvent(AdminEvent event, boolean includeRepresentation) {
-		if (topicAdminEvents != null) {
+		if (topicAdminEvents != null && 
+		    (this.adminEventResourceTypes == null || 
+			 this.adminEventResourceTypes.length == 0 || 
+			 this.adminEventResourceTypes.contains(event.resourceType)) && 
+			 (this.adminEventOperationTypes == null || 
+			 this.adminEventOperationTypes.length == 0 || 
+			 this.adminEventOperationTypes.contains(event.operationType))) {
 			try {
 				produceEvent(mapper.writeValueAsString(event), topicAdminEvents);
 			} catch (JsonProcessingException | ExecutionException | TimeoutException e) {

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
@@ -23,12 +23,13 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 	private String[] events;
 	private String[] adminEventResourceTypes;
 	private String[] adminEventOperationTypes;
+	private String[] adminStrictEventTypes;
 	private Map<String, Object> kafkaProducerProperties;
 
 	@Override
 	public EventListenerProvider create(KeycloakSession session) {
 		if (instance == null) {
-			instance = new KafkaEventListenerProvider(bootstrapServers, clientId, topicEvents, events, topicAdminEvents, adminEventResourceTypes, adminEventOperationTypes,
+			instance = new KafkaEventListenerProvider(bootstrapServers, clientId, topicEvents, events, topicAdminEvents, adminEventResourceTypes, adminEventOperationTypes, adminStrictEventTypes,
 					kafkaProducerProperties, new KafkaStandardProducerFactory());
 		}
 
@@ -49,6 +50,7 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 		topicAdminEvents = config.get("topicAdminEvents", System.getenv("KAFKA_ADMIN_TOPIC"));
 		String adminEventResourceTypesString = config.get("adminEventResourceTypes", System.getenv("KAFKA_ADMIN_EVENT_RESOURCE_TYPES"));
 		String adminEventOperationTypesString = config.get("adminEventOperationTypes", System.getenv("KAFKA_ADMIN_EVENT_OPERATION_TYPES"));
+		String adminStrictEventTypesString = config.get("adminStrictEventTypes", System.getenv("KAFKA_ADMIN_EVENT_STRICT_TYPES"));
 
 		if (adminEventResourceTypesString != null) {
 			adminEventResourceTypes = adminEventResourceTypesString.split(",");
@@ -56,6 +58,10 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 
 		if (adminEventOperationTypesString != null) {
 			adminEventOperationTypes = adminEventOperationTypesString.split(",");
+		}
+
+		if (adminStrictEventTypesString != null) {
+			adminStrictEventTypes = adminStrictEventTypesString.split(",");
 		}
 
 		String eventsString = config.get("events", System.getenv("KAFKA_EVENTS"));

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
@@ -47,8 +47,16 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 		clientId = config.get("clientId", System.getenv("KAFKA_CLIENT_ID"));
 		bootstrapServers = config.get("bootstrapServers", System.getenv("KAFKA_BOOTSTRAP_SERVERS"));
 		topicAdminEvents = config.get("topicAdminEvents", System.getenv("KAFKA_ADMIN_TOPIC"));
-		adminEventResourceTypes = config.get("adminEventResourceTypes", System.getenv("KAFKA_ADMIN_EVENT_RESOURCE_TYPES"));
-		adminEventOperationTypes = config.get("adminEventOperationTypes", System.getenv("KAFKA_ADMIN_EVENT_OPERATION_TYPES"));
+		String adminEventResourceTypesString = config.get("adminEventResourceTypes", System.getenv("KAFKA_ADMIN_EVENT_RESOURCE_TYPES"));
+		String adminEventOperationTypesString = config.get("adminEventOperationTypes", System.getenv("KAFKA_ADMIN_EVENT_OPERATION_TYPES"));
+
+		if (adminEventResourceTypesString != null) {
+			adminEventResourceTypes = adminEventResourceTypesString.split(",");
+		}
+
+		if (adminEventOperationTypesString != null) {
+			adminEventOperationTypes = adminEventOperationTypesString.split(",");
+		}
 
 		String eventsString = config.get("events", System.getenv("KAFKA_EVENTS"));
 

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
@@ -21,15 +21,13 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 	private String topicAdminEvents;
 	private String clientId;
 	private String[] events;
-	private String[] adminEventResourceTypes;
-	private String[] adminEventOperationTypes;
 	private String[] adminStrictEventTypes;
 	private Map<String, Object> kafkaProducerProperties;
 
 	@Override
 	public EventListenerProvider create(KeycloakSession session) {
 		if (instance == null) {
-			instance = new KafkaEventListenerProvider(bootstrapServers, clientId, topicEvents, events, topicAdminEvents, adminEventResourceTypes, adminEventOperationTypes, adminStrictEventTypes,
+			instance = new KafkaEventListenerProvider(bootstrapServers, clientId, topicEvents, events, topicAdminEvents, adminStrictEventTypes,
 					kafkaProducerProperties, new KafkaStandardProducerFactory());
 		}
 
@@ -48,17 +46,7 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 		clientId = config.get("clientId", System.getenv("KAFKA_CLIENT_ID"));
 		bootstrapServers = config.get("bootstrapServers", System.getenv("KAFKA_BOOTSTRAP_SERVERS"));
 		topicAdminEvents = config.get("topicAdminEvents", System.getenv("KAFKA_ADMIN_TOPIC"));
-		String adminEventResourceTypesString = config.get("adminEventResourceTypes", System.getenv("KAFKA_ADMIN_EVENT_RESOURCE_TYPES"));
-		String adminEventOperationTypesString = config.get("adminEventOperationTypes", System.getenv("KAFKA_ADMIN_EVENT_OPERATION_TYPES"));
 		String adminStrictEventTypesString = config.get("adminStrictEventTypes", System.getenv("KAFKA_ADMIN_EVENT_STRICT_TYPES"));
-
-		if (adminEventResourceTypesString != null) {
-			adminEventResourceTypes = adminEventResourceTypesString.split(",");
-		}
-
-		if (adminEventOperationTypesString != null) {
-			adminEventOperationTypes = adminEventOperationTypesString.split(",");
-		}
 
 		if (adminStrictEventTypesString != null) {
 			adminStrictEventTypes = adminStrictEventTypesString.split(",");

--- a/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
+++ b/src/main/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactory.java
@@ -21,12 +21,14 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 	private String topicAdminEvents;
 	private String clientId;
 	private String[] events;
+	private String[] adminEventResourceTypes;
+	private String[] adminEventOperationTypes;
 	private Map<String, Object> kafkaProducerProperties;
 
 	@Override
 	public EventListenerProvider create(KeycloakSession session) {
 		if (instance == null) {
-			instance = new KafkaEventListenerProvider(bootstrapServers, clientId, topicEvents, events, topicAdminEvents,
+			instance = new KafkaEventListenerProvider(bootstrapServers, clientId, topicEvents, events, topicAdminEvents, adminEventResourceTypes, adminEventOperationTypes,
 					kafkaProducerProperties, new KafkaStandardProducerFactory());
 		}
 
@@ -45,6 +47,8 @@ public class KafkaEventListenerProviderFactory implements EventListenerProviderF
 		clientId = config.get("clientId", System.getenv("KAFKA_CLIENT_ID"));
 		bootstrapServers = config.get("bootstrapServers", System.getenv("KAFKA_BOOTSTRAP_SERVERS"));
 		topicAdminEvents = config.get("topicAdminEvents", System.getenv("KAFKA_ADMIN_TOPIC"));
+		adminEventResourceTypes = config.get("adminEventResourceTypes", System.getenv("KAFKA_ADMIN_EVENT_RESOURCE_TYPES"));
+		adminEventOperationTypes = config.get("adminEventOperationTypes", System.getenv("KAFKA_ADMIN_EVENT_OPERATION_TYPES"));
 
 		String eventsString = config.get("events", System.getenv("KAFKA_EVENTS"));
 

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -21,7 +21,7 @@ class KafkaEventListenerProviderTests {
 	@BeforeEach
 	void setUp() throws Exception {
 		factory = new KafkaMockProducerFactory();
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin-events", Map.of(),
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin-events", new String[] {}, new String[] {}, Map.of(),
 				factory);
 	}
 
@@ -59,7 +59,7 @@ class KafkaEventListenerProviderTests {
 
 	@Test
 	void shouldDoNothingWhenTopicAdminEventsIsNull() throws Exception {
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, Map.of(), factory);
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, Map.of(), new String[] {}, new String[] {}, factory);
 		AdminEvent event = new AdminEvent();
 		MockProducer<?, ?> producer = getProducerUsingReflection();
 

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -59,7 +59,7 @@ class KafkaEventListenerProviderTests {
 
 	@Test
 	void shouldDoNothingWhenTopicAdminEventsIsNull() throws Exception {
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, Map.of(), new String[] {}, new String[] {}, factory);
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, new String[] {}, new String[] {}, Map.of(), factory);
 		AdminEvent event = new AdminEvent();
 		MockProducer<?, ?> producer = getProducerUsingReflection();
 

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -77,7 +77,7 @@ class KafkaEventListenerProviderTests {
 	}
 
 	@Test
-	void shouldProduceEventForMatchingEvent_whenStrictEventMatchingFilterApplied() throws Exception {
+	void shouldProduceEventForMatchingEventWhenStrictEventMatchingFilterApplied() throws Exception {
 
 		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"CREATE__GROUP_MEMBERSHIP"}, Map.of(), factory);
     MockProducer<?, ?> producer = getProducerUsingReflection();

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -89,7 +89,7 @@ class KafkaEventListenerProviderTests {
 		KafkaProducerFactory slowFactory = (clientId, bootstrapServer, optionalProperties) -> slowProducer;
 
 		KafkaEventListenerProvider slowListener = new KafkaEventListenerProvider("", "", "",
-				new String[] { "REGISTER" }, "admin-events", Map.of(), slowFactory);
+				new String[] { "REGISTER" }, "admin-events", new String[] {}, Map.of(), slowFactory);
 
 		Event event = new Event();
 		event.setType(EventType.REGISTER);

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventType;
 import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.OperationType;
 
 class KafkaEventListenerProviderTests {
 
@@ -21,7 +23,7 @@ class KafkaEventListenerProviderTests {
 	@BeforeEach
 	void setUp() throws Exception {
 		factory = new KafkaMockProducerFactory();
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin-events", new String[] {}, new String[] {}, Map.of(),
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin-events", new String[] {}, new String[] {}, new String[] {}, Map.of(),
 				factory);
 	}
 
@@ -59,7 +61,7 @@ class KafkaEventListenerProviderTests {
 
 	@Test
 	void shouldDoNothingWhenTopicAdminEventsIsNull() throws Exception {
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, new String[] {}, new String[] {}, Map.of(), factory);
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, new String[] {}, new String[] {}, new String[] {}, Map.of(), factory);
 		AdminEvent event = new AdminEvent();
 		MockProducer<?, ?> producer = getProducerUsingReflection();
 
@@ -74,4 +76,123 @@ class KafkaEventListenerProviderTests {
 		return (MockProducer<?, ?>) producerField.get(listener);
 	}
 
+	@Test
+	void shouldProduceEvent_whenResourceTypeMatchesFilter_andOperationTypeNotFiltered() throws Exception {
+
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {}, new String[] {}, Map.of(), factory);
+		AdminEvent event = new AdminEvent();
+
+		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event, false);
+
+		assertEquals(1, producer.history().size());
+	}
+
+  @Test
+	void shouldNotProduceEvent_whenResourceTypeDoesNotMatchFilter() throws Exception {
+
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {}, new String[] {}, Map.of(), factory);
+		AdminEvent event = new AdminEvent();
+
+		event.setResourceType(ResourceType.REALM_ROLE_MAPPING);
+
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event, false);
+
+		assertTrue(producer.history().isEmpty());
+	}
+
+  @Test
+	void shouldProduceEvent_whenOperationTypeMatchesFilter_andResourceTypeNotFiltered() throws Exception {
+
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {}, new String[] {"CREATE"}, new String[] {}, Map.of(), factory);
+		AdminEvent event = new AdminEvent();
+
+		event.setOperationType(OperationType.CREATE);
+		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event, false);
+
+		assertEquals(1, producer.history().size());
+	}
+
+	@Test
+	void shouldProduceEvent_whenBothResourceTypeAndOperationTypeMatchFilters() throws Exception {
+
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {"CREATE"}, new String[] {}, Map.of(), factory);
+		AdminEvent event = new AdminEvent();
+
+		event.setOperationType(OperationType.CREATE);
+		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event, false);
+
+		assertEquals(1, producer.history().size());
+	}
+
+	@Test
+	void shouldNotProduceEvent_whenResourceTypeMatchesButOperationTypeDoesNotMatch() throws Exception {
+
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {"DELETE"}, new String[] {}, Map.of(), factory);
+		AdminEvent event = new AdminEvent();
+
+		event.setOperationType(OperationType.CREATE);
+		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		listener.onEvent(event, false);
+
+		assertTrue(producer.history().isEmpty());
+	}
+
+	@Test
+	void shouldProduceEventOnlyForMatchingEvent_whenMultipleEventsProcessed() throws Exception {
+
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {"CREATE"}, new String[] {}, Map.of(), factory);
+    MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		AdminEvent matchingEvent = new AdminEvent();
+		matchingEvent.setOperationType(OperationType.CREATE);
+		matchingEvent.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		AdminEvent nonMatchingEvent = new AdminEvent();
+		nonMatchingEvent.setOperationType(OperationType.DELETE);
+		nonMatchingEvent.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		listener.onEvent(matchingEvent, false);
+		listener.onEvent(nonMatchingEvent, false);
+
+		assertEquals(1, producer.history().size());
+	}
+
+	@Test
+	void shouldProduceEventForMatchingEvent_whenStrictEventMatchingFilterApplied() throws Exception {
+
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {}, new String[] {}, new String[] {"CREATE__GROUP_MEMBERSHIP"}, Map.of(), factory);
+    MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		AdminEvent matchingEvent = new AdminEvent();
+		matchingEvent.setOperationType(OperationType.CREATE);
+		matchingEvent.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		AdminEvent nonMatchingEvent = new AdminEvent();
+		nonMatchingEvent.setOperationType(OperationType.DELETE);
+		nonMatchingEvent.setResourceType(ResourceType.GROUP_MEMBERSHIP);
+
+		listener.onEvent(matchingEvent, false);
+		listener.onEvent(nonMatchingEvent, false);
+
+		assertEquals(1, producer.history().size());
+		assertTrue(producer.history().get(0).value().toString().contains(String.format("\"operationType\":\"%s\"", matchingEvent.getOperationType().name())));
+		assertTrue(producer.history().get(0).value().toString().contains(String.format("\"resourceType\":\"%s\"", matchingEvent.getResourceTypeAsString())));
+	}
 }

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -23,7 +23,7 @@ class KafkaEventListenerProviderTests {
 	@BeforeEach
 	void setUp() throws Exception {
 		factory = new KafkaMockProducerFactory();
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin-events", new String[] {}, new String[] {}, new String[] {}, Map.of(),
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin-events", new String[] {}, Map.of(),
 				factory);
 	}
 
@@ -61,7 +61,7 @@ class KafkaEventListenerProviderTests {
 
 	@Test
 	void shouldDoNothingWhenTopicAdminEventsIsNull() throws Exception {
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, new String[] {}, new String[] {}, new String[] {}, Map.of(), factory);
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, null, new String[] {}, Map.of(), factory);
 		AdminEvent event = new AdminEvent();
 		MockProducer<?, ?> producer = getProducerUsingReflection();
 
@@ -77,107 +77,9 @@ class KafkaEventListenerProviderTests {
 	}
 
 	@Test
-	void shouldProduceEvent_whenResourceTypeMatchesFilter_andOperationTypeNotFiltered() throws Exception {
-
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {}, new String[] {}, Map.of(), factory);
-		AdminEvent event = new AdminEvent();
-
-		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
-
-		MockProducer<?, ?> producer = getProducerUsingReflection();
-
-		listener.onEvent(event, false);
-
-		assertEquals(1, producer.history().size());
-	}
-
-  @Test
-	void shouldNotProduceEvent_whenResourceTypeDoesNotMatchFilter() throws Exception {
-
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {}, new String[] {}, Map.of(), factory);
-		AdminEvent event = new AdminEvent();
-
-		event.setResourceType(ResourceType.REALM_ROLE_MAPPING);
-
-		MockProducer<?, ?> producer = getProducerUsingReflection();
-
-		listener.onEvent(event, false);
-
-		assertTrue(producer.history().isEmpty());
-	}
-
-  @Test
-	void shouldProduceEvent_whenOperationTypeMatchesFilter_andResourceTypeNotFiltered() throws Exception {
-
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {}, new String[] {"CREATE"}, new String[] {}, Map.of(), factory);
-		AdminEvent event = new AdminEvent();
-
-		event.setOperationType(OperationType.CREATE);
-		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
-
-		MockProducer<?, ?> producer = getProducerUsingReflection();
-
-		listener.onEvent(event, false);
-
-		assertEquals(1, producer.history().size());
-	}
-
-	@Test
-	void shouldProduceEvent_whenBothResourceTypeAndOperationTypeMatchFilters() throws Exception {
-
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {"CREATE"}, new String[] {}, Map.of(), factory);
-		AdminEvent event = new AdminEvent();
-
-		event.setOperationType(OperationType.CREATE);
-		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
-
-		MockProducer<?, ?> producer = getProducerUsingReflection();
-
-		listener.onEvent(event, false);
-
-		assertEquals(1, producer.history().size());
-	}
-
-	@Test
-	void shouldNotProduceEvent_whenResourceTypeMatchesButOperationTypeDoesNotMatch() throws Exception {
-
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {"DELETE"}, new String[] {}, Map.of(), factory);
-		AdminEvent event = new AdminEvent();
-
-		event.setOperationType(OperationType.CREATE);
-		event.setResourceType(ResourceType.GROUP_MEMBERSHIP);
-
-		MockProducer<?, ?> producer = getProducerUsingReflection();
-
-		listener.onEvent(event, false);
-
-		assertTrue(producer.history().isEmpty());
-	}
-
-	@Test
-	void shouldProduceEventOnlyForMatchingEvent_whenMultipleEventsProcessed() throws Exception {
-
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"GROUP_MEMBERSHIP"}, new String[] {"CREATE"}, new String[] {}, Map.of(), factory);
-    MockProducer<?, ?> producer = getProducerUsingReflection();
-
-		AdminEvent matchingEvent = new AdminEvent();
-		matchingEvent.setOperationType(OperationType.CREATE);
-		matchingEvent.setResourceType(ResourceType.GROUP_MEMBERSHIP);
-
-		AdminEvent nonMatchingEvent = new AdminEvent();
-		nonMatchingEvent.setOperationType(OperationType.DELETE);
-		nonMatchingEvent.setResourceType(ResourceType.GROUP_MEMBERSHIP);
-
-		listener.onEvent(matchingEvent, false);
-		listener.onEvent(nonMatchingEvent, false);
-
-		assertEquals(1, producer.history().size());
-	}
-
-	@Test
 	void shouldProduceEventForMatchingEvent_whenStrictEventMatchingFilterApplied() throws Exception {
 
-		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {}, new String[] {}, new String[] {"CREATE__GROUP_MEMBERSHIP"}, Map.of(), factory);
+		listener = new KafkaEventListenerProvider("", "", "", new String[] { "REGISTER" }, "admin_events", new String[] {"CREATE__GROUP_MEMBERSHIP"}, Map.of(), factory);
     MockProducer<?, ?> producer = getProducerUsingReflection();
 
 		AdminEvent matchingEvent = new AdminEvent();


### PR DESCRIPTION
### Admin Event Filtering Configuration

Keycloak admin event filtering supports fine-grained control over which admin events are processed and sent to Kafka:

- `KAFKA_ADMIN_EVENT_STRICT_TYPES`: Comma-separated list of strict event type combinations in the format `OPERATION__RESOURCE_TYPE` (e.g., `DELETE__GROUP_MEMBERSHIP`). 

#### Example usage (environment settings):
The advantage of strict event type combinations is that you can handle both resource types but for different operation types. For example:
```yaml
KAFKA_ADMIN_EVENT_STRICT_TYPES: DELETE__GROUP_MEMBERSHIP, UPDATE__USER
```

- This configuration would process **only** the defined pairs of types: `DELETE` on `GROUP_MEMBERSHIP`, and `UPDATE` on `USER`.


