### PR TITLE
upgrade: Kafka 4.2.0, Keycloak 26.5.5, KRaft docker-compose, improved tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # https://www.keycloak.org/server/containers
-FROM quay.io/keycloak/keycloak:19.0.3
-RUN curl -sL https://github.com/SnuK87/keycloak-kafka/releases/download/1.1.1/keycloak-kafka-1.1.1-jar-with-dependencies.jar -o /opt/keycloak/providers/keycloak-kafka-1.1.1-jar-with-dependencies.jar
+FROM maven:3.9-eclipse-temurin-21 AS builder
+WORKDIR /build
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM quay.io/keycloak/keycloak:26.5.5
+COPY --from=builder /build/target/keycloak-kafka-*-jar-with-dependencies.jar /opt/keycloak/providers/
 RUN /opt/keycloak/bin/kc.sh build
 
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Simple module for [Keycloak](https://www.keycloak.org/) to produce keycloak even
 
 **Tested with** 
 
-Kafka version: `2.12-2.1.x`, `2.12-2.4.x`, `2.12-2.5.x`, `2.13-2.8`, `2.13-3.3.x`
+Kafka version: `2.12-2.1.x`, `2.12-2.4.x`, `2.12-2.5.x`, `2.13-2.8`, `2.13-3.3.x`, `4.2.x`
 
-Keycloak version: `19.0.x, 21.0.x`
+Keycloak version: `19.0.x, 21.0.x, 26.x`
 
-Java version: `17`
+Java version: `17`, `21`
 
 Check out [this older version](https://github.com/SnuK87/keycloak-kafka/tree/1.1.1) to run the module on a Wildfly server
 
@@ -31,6 +31,15 @@ Just use the following command to build the jar file.
 ```bash
 mvn clean package
 ```
+
+## Running Tests
+Unit tests can be run locally with Maven or via Docker (no local Maven installation required):
+
+```bash
+docker compose --profile test run --rm test
+```
+
+Maven dependencies are cached in a named Docker volume (`maven-cache`) so subsequent runs are fast.
 
 ## Installation
 First you need to build or [download](https://github.com/SnuK87/keycloak-kafka/releases) the keycloak-kafka module.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   keycloak:
     depends_on:
@@ -11,31 +10,33 @@ services:
       KEYCLOAK_ADMIN_PASSWORD: admin
       KAFKA_TOPIC: keycloak-events
       KAFKA_CLIENT_ID: keycloak
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9094
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
     command: start-dev
     
-  zookeeper:
-    restart: always
-    image: bitnami/zookeeper:latest
-    ports:
-      - "2181:2181"
-    environment:    
-      - ALLOW_ANONYMOUS_LOGIN=yes
-      
   kafka:
-    depends_on:
-      - "zookeeper"
-    image: bitnami/kafka:latest
+    image: apache/kafka:4.2.0
     ports:
       - "9092:9092"
-      - "9094:9094"
     environment:
-      KAFKA_CFG_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://kafka:9094
-      KAFKA_CFG_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INSIDE
-      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "keycloak-events:1:1"
-      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+  test:
+    image: maven:3.9-eclipse-temurin-21
+    profiles:
+      - test
+    working_dir: /app
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/app
+      - maven-cache:/root/.m2
+    command: mvn test
+
+volumes:
+  maven-cache:

--- a/pom.xml
+++ b/pom.xml
@@ -4,15 +4,15 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.snuk87.keycloak</groupId>
 	<artifactId>keycloak-kafka</artifactId>
-	<version>1.4.0</version>
+	<version>1.5.0</version>
 
 	<properties>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<keycloak.version>26.4.7</keycloak.version>
-		<kafka.version>4.1.1</kafka.version>
-		<junit.version>6.0.1</junit.version>
-		<jboss-logging.version>3.6.1.Final</jboss-logging.version>
+		<keycloak.version>26.5.5</keycloak.version>
+		<kafka.version>4.2.0</kafka.version>
+		<junit.version>6.0.3</junit.version>
+		<jboss-logging.version>3.6.2.Final</jboss-logging.version>
 	</properties>
 
 	<dependencies>
@@ -53,6 +53,13 @@
 					<artifactId>slf4j-api</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.16</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactoryTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderFactoryTests.java
@@ -1,0 +1,100 @@
+package com.github.snuk87.keycloak.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.Config.Scope;
+
+class KafkaEventListenerProviderFactoryTests {
+
+	private KafkaEventListenerProviderFactory factory;
+
+	@BeforeEach
+	void setUp() {
+		factory = new KafkaEventListenerProviderFactory();
+	}
+
+	private static Scope scopeOf(Map<String, String> props) {
+		return new Scope() {
+			@Override public String get(String key) { return props.get(key); }
+			@Override public String get(String key, String defaultValue) {
+				String v = props.get(key);
+				return v != null ? v : defaultValue;
+			}
+			@Override public Integer getInt(String key, Integer d) { return d; }
+			@Override public Long getLong(String key, Long d) { return d; }
+			@Override public Boolean getBoolean(String key, Boolean d) { return d; }
+			@Override public String[] getArray(String key) { return null; }
+			@Override public Scope scope(String... path) { return this; }
+			@Override public java.util.Set<String> getPropertyNames() { return props.keySet(); }
+			@Override public Scope root() { return this; }
+		};
+	}
+
+	@Test
+	void shouldThrowWhenTopicEventsIsNull() {
+		Scope scope = scopeOf(Map.of("clientId", "kc", "bootstrapServers", "localhost:9092"));
+		assertThrows(NullPointerException.class, () -> factory.init(scope));
+	}
+
+	@Test
+	void shouldThrowWhenClientIdIsNull() {
+		Scope scope = scopeOf(Map.of("topicEvents", "keycloak-events", "bootstrapServers", "localhost:9092"));
+		assertThrows(NullPointerException.class, () -> factory.init(scope));
+	}
+
+	@Test
+	void shouldThrowWhenBootstrapServersIsNull() {
+		Scope scope = scopeOf(Map.of("topicEvents", "keycloak-events", "clientId", "kc"));
+		assertThrows(NullPointerException.class, () -> factory.init(scope));
+	}
+
+	@Test
+	void shouldDefaultToRegisterEventWhenEventsNotConfigured() throws Exception {
+		Scope scope = scopeOf(Map.of(
+				"topicEvents", "keycloak-events",
+				"clientId", "kc",
+				"bootstrapServers", "localhost:9092"
+		));
+		factory.init(scope);
+
+		Field eventsField = KafkaEventListenerProviderFactory.class.getDeclaredField("events");
+		eventsField.setAccessible(true);
+		assertArrayEquals(new String[] { "REGISTER" }, (String[]) eventsField.get(factory));
+	}
+
+	@Test
+	void shouldSplitCommaSeparatedEventTypes() throws Exception {
+		Scope scope = scopeOf(Map.of(
+				"topicEvents", "keycloak-events",
+				"clientId", "kc",
+				"bootstrapServers", "localhost:9092",
+				"events", "REGISTER,LOGIN,LOGOUT"
+		));
+		factory.init(scope);
+
+		Field eventsField = KafkaEventListenerProviderFactory.class.getDeclaredField("events");
+		eventsField.setAccessible(true);
+		assertArrayEquals(new String[] { "REGISTER", "LOGIN", "LOGOUT" }, (String[]) eventsField.get(factory));
+	}
+
+	@Test
+	void shouldReturnSameInstanceOnMultipleCreate() {
+		Scope scope = scopeOf(Map.of(
+				"topicEvents", "keycloak-events",
+				"clientId", "kc",
+				"bootstrapServers", "localhost:9092"
+		));
+		factory.init(scope);
+
+		var first = factory.create(null);
+		var second = factory.create(null);
+		assertSame(first, second);
+	}
+}

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaEventListenerProviderTests.java
@@ -1,5 +1,6 @@
 package com.github.snuk87.keycloak.kafka;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,7 +10,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.producer.MockProducer;
-import org.apache.kafka.clients.producer.RoundRobinPartitioner;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,7 +83,12 @@ class KafkaEventListenerProviderTests {
 	@Test
 	void shouldNotBlockWhenKafkaIsUnavailable() throws Exception {
 		// Create a non-auto-completing MockProducer to simulate Kafka unavailability
-		MockProducer<String, String> slowProducer = new MockProducer<>(false, new RoundRobinPartitioner(), new StringSerializer(), new StringSerializer());
+		MockProducer<String, String> slowProducer = new MockProducer<String, String>(false, new Partitioner() {
+			@Override
+			public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) { return 0; }
+			@Override public void close() {}
+			@Override public void configure(Map<String, ?> configs) {}
+		}, new StringSerializer(), new StringSerializer());
 
 		
 		KafkaProducerFactory slowFactory = (clientId, bootstrapServer, optionalProperties) -> slowProducer;
@@ -111,6 +118,40 @@ class KafkaEventListenerProviderTests {
 		
 		// Verify the message was queued (even though not yet completed)
 		assertEquals(1, slowProducer.history().size());
+	}
+
+	@Test
+	void shouldProduceEventForEachConfiguredEventType() throws Exception {
+		listener = new KafkaEventListenerProvider("", "", "",
+				new String[] { "REGISTER", "LOGIN", "LOGOUT" }, "admin-events", Map.of(), factory);
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		Event loginEvent = new Event();
+		loginEvent.setType(EventType.LOGIN);
+		listener.onEvent(loginEvent);
+
+		Event logoutEvent = new Event();
+		logoutEvent.setType(EventType.LOGOUT);
+		listener.onEvent(logoutEvent);
+
+		assertEquals(2, producer.history().size());
+	}
+
+	@Test
+	void shouldIgnoreInvalidEventTypesOnConstruction() throws Exception {
+		assertDoesNotThrow(() -> new KafkaEventListenerProvider("", "", "",
+				new String[] { "NOT_A_REAL_EVENT", "REGISTER" }, "admin-events", Map.of(), factory));
+
+		listener = new KafkaEventListenerProvider("", "", "",
+				new String[] { "NOT_A_REAL_EVENT", "REGISTER" }, "admin-events", Map.of(), factory);
+		MockProducer<?, ?> producer = getProducerUsingReflection();
+
+		Event event = new Event();
+		event.setType(EventType.REGISTER);
+		listener.onEvent(event);
+
+		// REGISTER is valid and should still be produced; the invalid type is just skipped
+		assertEquals(1, producer.history().size());
 	}
 
 }

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaMockProducerFactory.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaMockProducerFactory.java
@@ -3,16 +3,26 @@ package com.github.snuk87.keycloak.kafka;
 import java.util.Map;
 
 import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Partitioner;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.RoundRobinPartitioner;
+import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 class KafkaMockProducerFactory implements KafkaProducerFactory {
 
+	private static final Partitioner NOOP_PARTITIONER = new Partitioner() {
+		@Override
+		public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+			return 0;
+		}
+		@Override public void close() {}
+		@Override public void configure(Map<String, ?> configs) {}
+	};
+
 	@Override
 	public Producer<String, String> createProducer(String clientId, String bootstrapServer,
 			Map<String, Object> optionalProperties) {
-		return new MockProducer<>(true, new RoundRobinPartitioner(), new StringSerializer(), new StringSerializer());
+		return new MockProducer<String, String>(true, NOOP_PARTITIONER, new StringSerializer(), new StringSerializer());
 	}
 
 }

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfigTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaProducerConfigTests.java
@@ -4,11 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.keycloak.Config.SystemPropertiesConfigProvider;
 
 class KafkaProducerConfigTests {
+
+	@AfterEach
+	void cleanUp() {
+		System.clearProperty("keycloak.retry.backoff.ms");
+		System.clearProperty("keycloak.max.block.ms");
+		System.clearProperty("keycloak.ssl.endpoint.identification.algorithm");
+	}
 
 	@Test
 	void shouldReturnMapWithConfigWhenPropertyExists() {
@@ -20,5 +28,14 @@ class KafkaProducerConfigTests {
 		Map<String, Object> expected = Map.of("retry.backoff.ms", "1000", "max.block.ms", "5000");
 
 		assertEquals(expected, config);
+	}
+
+	@Test
+	void shouldSetEmptyStringForDisabledSSLEndpointIdentification() {
+		System.setProperty("keycloak.ssl.endpoint.identification.algorithm", "disabled");
+
+		Map<String, Object> config = KafkaProducerConfig.init(new SystemPropertiesConfigProvider().scope());
+
+		assertEquals("", config.get("ssl.endpoint.identification.algorithm"));
 	}
 }

--- a/src/test/java/com/github/snuk87/keycloak/kafka/KafkaStandardProducerFactoryTests.java
+++ b/src/test/java/com/github/snuk87/keycloak/kafka/KafkaStandardProducerFactoryTests.java
@@ -1,0 +1,30 @@
+package com.github.snuk87.keycloak.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.Test;
+
+class KafkaStandardProducerFactoryTests {
+
+	@Test
+	void shouldCreateProducer() {
+		KafkaStandardProducerFactory factory = new KafkaStandardProducerFactory();
+		Producer<String, String> producer = factory.createProducer("test-client", "localhost:9092", Map.of());
+		assertNotNull(producer);
+		producer.close(Duration.ofMillis(100));
+	}
+
+	@Test
+	void shouldApplyOptionalProperties() {
+		KafkaStandardProducerFactory factory = new KafkaStandardProducerFactory();
+		Map<String, Object> extra = Map.of(ProducerConfig.ACKS_CONFIG, "all");
+		Producer<String, String> producer = factory.createProducer("test-client", "localhost:9092", extra);
+		assertNotNull(producer);
+		producer.close(Duration.ofMillis(100));
+	}
+}


### PR DESCRIPTION
## Summary

This PR upgrades the project to Kafka 4.2.0 and Keycloak 26.5.5, replaces the ZooKeeper-based docker-compose setup with KRaft, modernises the Dockerfile, and improves test coverage.

---

## Dependency Upgrades

| Dependency | From | To |
|---|---|---|
| kafka-clients | 4.1.1 | 4.2.0 |
| keycloak | 26.4.7 | 26.5.5 |
| junit-jupiter | 6.0.1 | 6.0.3 |
| jboss-logging | 3.6.1.Final | 3.6.2.Final |

---

## docker-compose.yml — KRaft Mode

Kafka 4.0 removed ZooKeeper support entirely. This PR:
- Removes the `zookeeper` service
- Switches Kafka to KRaft mode using `apache/kafka:4.2.0`
- Adds a `test` profile service so tests can be run via Docker without a local Maven installation:

```bash
docker compose --profile test run --rm test
```

---

## Dockerfile — Multi-stage Build

Replaced the old approach (downloading a pre-built JAR from GitHub releases) with a proper multi-stage build:
1. **Build stage**: `maven:3.9-eclipse-temurin-21` compiles and packages the JAR
2. **Runtime stage**: `quay.io/keycloak/keycloak:26.5.5`

---

## Tests

- Replaced deprecated `RoundRobinPartitioner` with an inline `Partitioner` implementation (the 3-arg `MockProducer` constructor without `Partitioner` was removed in Kafka 4.x)
- Added `slf4j-simple` as test-scoped dependency (required for `KafkaProducer` instantiation in unit tests)
- **New: `KafkaEventListenerProviderFactoryTests`** — 6 tests covering null validation, default REGISTER event, comma-separated event parsing, singleton pattern
- **New: `KafkaStandardProducerFactoryTests`** — 2 tests covering producer creation and optional properties
- **Extended: `KafkaProducerConfigTests`** — added SSL endpoint identification `disabled` → empty string test
- **Extended: `KafkaEventListenerProviderTests`** — added multiple event types and invalid event type handling tests

Total: **17 tests** (was 6)